### PR TITLE
Fix checker from crashing when package has multiple licenses

### DIFF
--- a/bin/license-checker-ci
+++ b/bin/license-checker-ci
@@ -77,7 +77,7 @@ function readConfig() {
 }
 
 function checkLicense(licenseString, packageString) {
-	if (licenseString.length === 0) {
+	if (typeof licenseString !== 'string' || licenseString.length === 0) {
 		return false;
 	}
 	/* use this code if you want to accept guessed packages


### PR DESCRIPTION
Packages like `json-schema@0.2.3` can return an array of licenses from `davglass/license-checker` - in this case `[ 'AFLv2.1', 'BSD' ]`

This causes license-checker-ci to crash as follows: `ERROR: Uncaught exception. Details: {}`

A better fix would be to check all licenses in these arrays, but I'm happy for now just to have it fail the check and need to add it to manualOverrides. Unless you want to make it smarter.