### PR TITLE
Best-efforts attempt to displaying offending path (#26).

### DIFF
--- a/bin/license-checker-ci
+++ b/bin/license-checker-ci
@@ -108,7 +108,8 @@ function processLicenseCheckerOutput(json) {
 			fail = true;
 			console.error(
 				`>>> Package "${key}" doesn\'t meet license requirements (${license}).\n` +
-				`    Repository: ${value.repository}\n`
+				`    Repository: ${value.repository}\n` +
+				`    License Location: ${value.licenseFile || 'UNKNOWN'}\n`
 			);
 		}
 	});


### PR DESCRIPTION
Sample:

```
Running command "node bin\license-checker-ci test\data\proj-license-issue-scope"
stdout:
No config file specified, using unmodified defaults.

stderr:
>>> Package "bson@0.2.22" doesn't meet license requirements (Apache License, Version 2.0).
    Repository: https://github.com/mongodb/js-bson
    License Location: C:\workspace\license-checker-d2l\test\data\proj-license-issue-scope\node_modules\bson\LICENSE

>>> Package "kerberos@0.0.4" doesn't meet license requirements (Apache*).
    Repository: https://github.com/christkv/kerberos
    License Location: C:\workspace\license-checker-d2l\test\data\proj-license-issue-scope\node_modules\kerberos\LICENSE

>>> Package "modm@0.4.1" doesn't meet license requirements (UNKNOWN).
    Repository: https://github.com/adioo/modm
    License Location: UNKNOWN

>>> Package "mongodb@1.4.14" doesn't meet license requirements (Apache License, Version 2.0).
    Repository: https://github.com/mongodb/node-mongodb-native
    License Location: C:\workspace\license-checker-d2l\test\data\proj-license-issue-scope\node_modules\mongodb\LICENSE

ERROR: Some licenses didn't pass the requirements (see above).
       Please check the offending packages or update the configuration file (.licensechecker.json).
       You can find more information at https://github.com/Brightspace/license-checker-ci

    √ should reject a non-whitelisted scope (2109ms)
```