### PR TITLE
Now shows full path to modules when its license fails the checker; resolves #26.

### DIFF
--- a/bin/license-checker-ci
+++ b/bin/license-checker-ci
@@ -113,7 +113,8 @@ function processLicenseCheckerOutput(json) {
 			failedLicenses[key] = license;
 			console.error(
 				`>>> Package "${key}" doesn\'t meet license requirements (${license}).\n` +
-				`    Repository: ${value.repository}\n`
+				`    Repository: ${value.repository}\n` +
+				`    Path: ${value.path || 'UNKNOWN'}\n`
 			);
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "bluebird": "3.5.0",
     "bower-license": "0.4.4",
-    "license-checker": "11.0.0",
+    "license-checker": "15.0.0",
     "lodash": "4.17.4",
     "semver": "5.3.0",
     "spdx": "0.5.1",


### PR DESCRIPTION
Depends on https://github.com/davglass/license-checker/pull/126.