### PR TITLE
Support licenses specified as SPDX expressions

### DIFF
--- a/bin/license-checker-ci
+++ b/bin/license-checker-ci
@@ -79,6 +79,15 @@ function readConfig() {
 	acceptedNonSpdx = partitions[1].concat('Project-Owner');
 }
 
+function satisfiesNoThrow(first, second) {
+	try {
+		return satisfies(first, second);
+	} catch (err) {
+		// throws on invalid SPDX ID
+		return false;
+	}
+}
+
 function checkLicense(licenseString, packageString) {
 	if (licenseString.length === 0) {
 		return false;
@@ -88,11 +97,11 @@ function checkLicense(licenseString, packageString) {
 		licenseString = licenseString.substring(0, licenseString.length - 1);
 	} */
 	return (
-		(acceptedSpdxExpr && spdxIds.includes(licenseString) && satisfies(licenseString, acceptedSpdxExpr))
-		|| acceptedNonSpdx.indexOf(licenseString) >= 0
+		acceptedNonSpdx.indexOf(licenseString) >= 0
 		|| packageString.startsWith(projectPackage.name + '@') // accept your own package
 		|| _.some(config.acceptedScopes, (scope) => packageString.startsWith(`@${scope}/`))
 		|| licenseString.startsWith(specialExemptionPrefix)
+		|| (acceptedSpdxExpr && satisfiesNoThrow(licenseString, acceptedSpdxExpr))
 	);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-license-checker",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-license-checker",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Simple tool to check licenses of all npm dependencies in a project",
   "license": "MIT",
   "repository": {

--- a/test/data/proj-bad-spdx-expression/.licensechecker.json
+++ b/test/data/proj-bad-spdx-expression/.licensechecker.json
@@ -1,0 +1,5 @@
+{
+  "manualOverrides": {
+	  "bluebird@3.4.7": "(MIT OR Invalid-SPDX-ID)"
+  }
+}

--- a/test/data/proj-bad-spdx-expression/package-lock.json
+++ b/test/data/proj-bad-spdx-expression/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-ok-range",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+    }
+  }
+}

--- a/test/data/proj-bad-spdx-expression/package.json
+++ b/test/data/proj-bad-spdx-expression/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "proj-ok-range",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bluebird": "3.4.7"
+  }
+}

--- a/test/data/proj-ok-spdx-expression/.licensechecker.json
+++ b/test/data/proj-ok-spdx-expression/.licensechecker.json
@@ -1,0 +1,5 @@
+{
+  "manualOverrides": {
+	  "bluebird@3.4.7": "(MIT OR Apache-2.0)"
+  }
+}

--- a/test/data/proj-ok-spdx-expression/package-lock.json
+++ b/test/data/proj-ok-spdx-expression/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-ok-range",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+    }
+  }
+}

--- a/test/data/proj-ok-spdx-expression/package.json
+++ b/test/data/proj-ok-spdx-expression/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "proj-ok-range",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bluebird": "3.4.7"
+  }
+}

--- a/test/testBin.js
+++ b/test/testBin.js
@@ -97,6 +97,14 @@ describe('Command invocation', () => {
 		assert.equal(checkProject(makeTestPath('proj-ok-override-special')), 0);
 	});
 
+	it('should allow valid SPDX expression', () => {
+		assert.equal(checkProject(makeTestPath('proj-ok-spdx-expression')), 0);
+	});
+
+	it('should reject invalid SPDX expression', () => {
+		assert.equal(checkProject(makeTestPath('proj-bad-spdx-expression')), 2);
+	});
+
 	it('self test', () => {
 		assert.equal(checkProject('.'), 0);
 	});


### PR DESCRIPTION
According to the `package.json` [docs](https://docs.npmjs.com/files/package.json#license), the `"license"` field may be an SPDX license expression syntax version 2.0 string (e.g. `"(ISC OR GPL-3.0)"`). Previously, the license checker rejected such license expressions as invalid. Now it supports them.