### PR TITLE
Add Python-2.0 to list of approved licenses

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -15,6 +15,7 @@
     "ISC",
     "MIT",
     "Public-Domain",
+    "Python-2.0",
     "Unlicense",
     "W3C",
     "WTFPL",


### PR DESCRIPTION
The Python 2.0 license has been approved by the Open Source Advisory.