### PR TITLE
chore: add GitHub action for automatically updating dependencies.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Update Dependencies
+on:
+  schedule:
+    # Runs monthly
+    - cron:  '0 13 1 * *'
+  workflow_dispatch:
+jobs:
+  update-deps:
+    name: Update dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@neverendingqs/gh-action-node-update-deps
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          bump-version: patch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,5 +14,3 @@ jobs:
       - uses: Brightspace/third-party-actions@neverendingqs/gh-action-node-update-deps
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          bump-version: patch


### PR DESCRIPTION
This action automatically updates deps via `npm-check-updates` and `npm audit --fix`, and creates a pull request with the changes.

Pros:
* Less noisy than using dependabot for every single dependency update

Cons:
* If the build breaks, it might be harder to identify which package change caused it
* Actions done by GitHub actions workflows do not trigger GitHub action workflows. This repo is currently using Travis CI, but if we ever switch to GitHub actions for CI, PRs created by this workflow won't trigger CI.