### PR TITLE
chore: ensure deps update workflow triggers other workflows.

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@neverendingqs/gh-action-node-update-deps
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}


### PR DESCRIPTION
From https://github.com/Brightspace/d2l-license-checker/pull/94

> Actions done by GitHub actions workflows do not trigger GitHub action workflows. This repo is currently using Travis CI, but if we ever switch to GitHub actions for CI, PRs created by this workflow won't trigger CI.

This PR should solve that problem now that we're on GitHub Actions.

I also took the liberty to rename the file to a file name that made more sense.