### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/config/default_config.json @Brightspace/open-source-advisory


### PR DESCRIPTION
Ensure that the Open Source Advisory team is notified before changes to the defaults are made.