### PR TITLE
feat(default_config): allow later versions of gitconfiglocal.

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -67,7 +67,7 @@
     "fast-xml-parser@<3": "MIT",
     "formatio@<2": "BSD-3-Clause",
     "formidable@<2": "MIT",
-    "gitconfiglocal@<1": "BSD-3-Clause",
+    "gitconfiglocal@<3": "BSD-3-Clause",
     "glob@<4": "ISC",
     "graceful-fs@<3": "ISC",
     "iana-rels@<1": "MIT",


### PR DESCRIPTION
Follow-up of https://github.com/Brightspace/d2l-license-checker/pull/110. Current version is `2.1.0`.