### PR TITLE
BREAKING CHANGE: remove support for node 10 and 15, and add support for 16.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        node: ['10', '12', '14', '15']
+        node: ['12', '14', '16']
     steps:
       - name: Checkout
         uses: Brightspace/third-party-actions@actions/checkout


### PR DESCRIPTION
Maintain support for all LTS and Current versions.