### PR TITLE
feat: add production only and development only options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ A simple tool to check licenses of all npm dependencies in a project against an 
 
 If licenses do not pass the test, you can run `npm run license-check -- --generate-template > .licensechecker.template.json` to generate a template file that can be copied and pasted into the config file for easy overrides.
 
+## Narrowing Analysis
+
+If you only want to check a certain type of dependency, you can supply either `--production-only` or `--development-only` to only check the associated dependency type. These options are mutually exclusive, meaning you can only supply one of the flags. Excluding both will simply check all dependencies.
+
 ## Configuration file
 
 The configuration file is a simple JSON file with the following optional entries:

--- a/bin/d2l-license-checker
+++ b/bin/d2l-license-checker
@@ -17,13 +17,19 @@ const OverrideHelper = require('../lib/override-helper');
 const defaultConfigFilePath = '.licensechecker.json';
 const argv = require('yargs')
 	.usage(
-	'$0 [project-path [config-file-path]]\n\n' +
+		'$0 [project-path [config-file-path]]\n\n' +
 		'  If no project path is given, the current directory with be used\n' +
 		`  If no config path is given, the file <project-path>/${defaultConfigFilePath} will be used as default.`)
 	.help('h')
 	.alias('h', 'help')
 	.alias('t', 'generate-template')
 	.describe('t', 'Outputs licenses that failed the checker to standard out.')
+	.alias('p', 'production-only')
+	.describe('p', 'Only include production dependencies in analysis.')
+	.alias('d', 'development-only')
+	.describe('d', 'Only include development dependencies in analysis.')
+	.conflicts('d', 'p')
+	.boolean(['d', 'p', 't'])
 	.strict()
 	.argv;
 const projectDir = argv._[0] || process.cwd();
@@ -46,7 +52,7 @@ function handleError(err, code) {
 
 function readConfig() {
 	try {
-		let data = fs.readFileSync(configFilePath, {encoding: 'utf8'});
+		let data = fs.readFileSync(configFilePath, { encoding: 'utf8' });
 		config = JSON.parse(data);
 	} catch (err) {
 		console.error('No config file specified, using unmodified defaults.');
@@ -147,8 +153,14 @@ const npmChecker = promisify(checker.init);
 
 readConfig();
 
+const checkerConfig = {
+	start: projectDir,
+	production: argv.productionOnly || undefined,
+	development: argv.developmentOnly || undefined
+};
+
 // the semantics of our arguments are different than license-checker (see their --help)
-npmChecker({ start: projectDir })
+npmChecker(checkerConfig)
 	.catch(err => handleError('license-checker did not run successfully. Details:\n' + JSON.stringify(err)))
 	.then(json => processLicenseCheckerOutput(json))
 	.catch(err => handleError('Uncaught exception. Details:\n' + JSON.stringify(err)));


### PR DESCRIPTION
This adds options to narrow down which dependencies we analyze. Options are mutually exclusive. I decided to keep the default behaviour when neither flag is supplied which is to check everything. Resolves #91. 