### PR TITLE
Add memory-stream override

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -85,6 +85,7 @@
     "log-driver@<2": "ISC",
     "log@<2": "MIT",
     "map-stream@<1": "MIT",
+    "memory-stream@<1": "MIT",
     "mime@<2": "MIT",
     "ms@<1": "MIT",
     "murmurhash@<1": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-license-checker",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Simple tool to check licenses of all npm dependencies in a project",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The memory-stream@0.0.3 npm package has a typo for the license `MMIT`, which has been corrected in version 1.0 to `MIT`. The license should have been MIT according github (see links below). I traced this packaging to being a dependency for the @aws-sdk/client-lambda that is used in the lambda-proxy-invoker shared library for PBMM.  I have a failing PR in Attributes Import Service that needs this update. https://github.com/Brightspace/attributes-import-service/pull/736

https://www.npmjs.com/package/memory-stream/v/0.0.3
https://github.com/panthershark/memory-stream/blame/master/LICENSE