### PR TITLE
chore(workflows/workflow): increase CI timeout.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     strategy:
       matrix:
         node: ['12', '14', '16']


### PR DESCRIPTION
In response to https://github.com/Brightspace/d2l-license-checker/actions/runs/1778783241.