### PR TITLE
chore(workflows/workflow): use correct semantic-release action branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,7 @@ jobs:
         uses: Brightspace/third-party-actions@actions/setup-node
       - name: Semantic Release
         if: github.ref == 'refs/heads/master'
-        uses: BrightspaceUI/actions/semantic-release@master
+        uses: BrightspaceUI/actions/semantic-release@main
         with:
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: true


### PR DESCRIPTION
[`BrightspaceUI/actions`](https://github.com/BrightspaceUI/actions) has switched to `main` some time ago