### PR TITLE
ci: use correct default branch for semantic-release

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,6 +45,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         uses: BrightspaceUI/actions/semantic-release@main
         with:
+          DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
#162 broke the build as `semantic-release` action uses `main` as the default branch now