### PR TITLE
GAUD-5048 -  Use new release token

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,6 +46,6 @@ jobs:
         uses: BrightspaceUI/actions/semantic-release@main
         with:
           DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        node: ['12', '14', '16', '18']
+        node: ['12', '14', '16', '18', '20']
     steps:
       - name: Checkout
         uses: Brightspace/third-party-actions@actions/checkout
@@ -41,6 +41,8 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: 20
       - name: Semantic Release
         if: github.ref == 'refs/heads/master'
         uses: BrightspaceUI/actions/semantic-release@main

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://api.travis-ci.com/Brightspace/d2l-license-checker.svg?branch=master)](https://travis-ci.com/Brightspace/d2l-license-checker-ci)
-
 # d2l-license-checker
 
 A simple tool to check licenses of all npm dependencies in a project against an approved set of licenses. Can be added to a test suite / CI to get a warning about packages not meeting predefined license requirements. This is basically a wrapper around [`davglass/license-checker`](https://github.com/davglass/license-checker)
@@ -53,10 +51,8 @@ The configuration file is a simple JSON file with the following optional entries
 
 * `"ignoreUnusedManualOverrides"`: Set it to true if you do not want warnings logged when you have unused manual overrides (`false` by default)
 
-## Contributing
+## Versioning and Releasing
 
-1. Update code.
-1. Update version in `package.json`.
-1. Commit/merge changes via pull request.
-1. Run `Release new version` GitHub action workflow.
-1. Travis will automatically publish tagged commits to npmjs.org.
+This repo is configured to use `semantic-release`. Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `main`.
+
+To learn how to create major releases and release from maintenance branches, refer to the [semantic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release) documentation.


### PR DESCRIPTION
The `brightspace-bot` and `D2L_GITHUB_TOKEN` are no longer needed for `release` workflows. Instead, we have a [new `D2L_RELEASE_TOKEN`](https://github.com/Brightspace/repo-settings/blob/main/docs/release_action_setup.md) that has the ability to bypass the repo ruleset (configured in https://github.com/Brightspace/repo-settings/pull/1679) and org-level ruleset.

Before merging, I will:
- Confirm the new ruleset matches the old branch protection rule before deleting it
- Remove `brightspace-bot` as a repo contributor
- Confirm the `D2L_RELEASE_TOKEN` is available and remove this repo's access to `D2L_GITHUB_TOKEN`