### PR TITLE
fix: LURV-2167 - Add MIT-0 to approved licenses

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -14,6 +14,7 @@
     "EPL-1.0",
     "ISC",
     "MIT",
+    "MIT-0",
     "Public-Domain",
     "Python-2.0",
     "Unlicense",


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/LURV-2167

Adds [MIT No Attribution (MIT-0)](https://spdx.org/licenses/MIT-0.html) to our approved licenses list. The MIT-0 license is the same at the MIT license, but with the attribution paragraph removed.

The MIT-0 license is [OSI approved](https://opensource.org/license/mit-0).