### PR TITLE
Adding BlueOak to list of approved licenses

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -3,6 +3,7 @@
     "0BSD",
     "Apache-1.0",
     "Apache-2.0",
+    "BlueOak-1.0.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC-BY-1.0",


### PR DESCRIPTION
## PR Summary

There has been some chatter over on #open-source about this license. 
In particular @KaiPrince indicated that as of[ Jan 31, 2024 it was approved by OSI.](https://d2l.slack.com/archives/C58ACLE9M/p1706746491277479)

I am opening this PR in an attempt to converge on a decision around if we can add it to our approved licenses. [I have a production dependency whose next major version has a sub-dependency with this license]