### PR TITLE
Convert test file to ESM

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,4 @@
 {
+  "spec": "test/**/*.test.mjs",
   "timeout": 12000
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ module.exports = [
 	...nodeConfig.map(config => ({
 		...config,
 		files: [
-			'**/*.js',
+			'**/*.{js,mjs}',
 			'bin/d2l-license-checker',
 			'bin/license-checker-ci'
 		],
@@ -50,7 +50,7 @@ module.exports = [
 	})),
 	{
 		...promiseConfig,
-		files: ['**/*.js'],
+		files: ['**/*.{js,mjs}'],
 		rules: {
 			...promiseConfig.rules,
 			'promise/prefer-await-to-then': ['error', { strict: true }]
@@ -58,16 +58,16 @@ module.exports = [
 	},
 	{
 		...commentsConfig,
-		files: ['**/*.js']
+		files: ['**/*.{js,mjs}']
 	},
 	jsonConfig,
 	...testingConfig.map(config => ({
 		...config,
-		files: ['test/**/*.test.js']
+		files: ['test/**/*.test.{js,mjs}']
 	})),
 	{
 		...mochaConfig,
-		files: ['test/**/*.test.js'],
+		files: ['test/**/*.test.{js,mjs}'],
 		rules: {
 			...mochaConfig.rules,
 			'mocha/consistent-spacing-between-blocks': 'off',
@@ -77,7 +77,7 @@ module.exports = [
 		}
 	},
 	{
-		files: ['test/**/*.test.js'],
+		files: ['test/**/*.test.{js,mjs}'],
 		plugins: {
 			'chai-friendly': chaiFriendlyPlugin
 		},

--- a/test/bin.test.mjs
+++ b/test/bin.test.mjs
@@ -1,6 +1,6 @@
-const { expect } = require('chai');
-const { join } = require('path');
-const { spawnSync } = require('child_process');
+import { expect } from 'chai';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
 
 const npmCmd = (process.platform === 'win32') ? 'npm.cmd' : 'npm';
 const dataDir = join('test', 'data');


### PR DESCRIPTION
Converts the test file from CommonJS to an ES module by renaming `bin.test.js` to `bin.test.mjs` and switching `require` calls to `import` statements. Updates `.mocharc.json` with a `spec` pattern for `.mjs` files and updates all eslint config file globs to use `{js,mjs}` notation.

https://desire2learn.atlassian.net/browse/QE-651