### PR TITLE
Standardize workflow step names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
     steps:
       - name: Checkout
         uses: Brightspace/third-party-actions@actions/checkout
-      - name: Setup Node
+      - name: Set up node
         uses: Brightspace/setup-node@main
         with:
           node-version: ${{matrix.node}}
           cache: npm
-      - name: npm install
+      - name: Install dependencies
         run: npm ci
-      - name: test
+      - name: Run tests
         run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: Brightspace/third-party-actions@actions/checkout
         with:
           persist-credentials: false
-      - name: Setup Node
+      - name: Set up node
         uses: Brightspace/setup-node@main
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
Aligns CI and release workflow step names with the conventions used in the test-reporting-* repos: lowercase "Set up node", "Install dependencies", and "Run tests" instead of the inconsistent casing and shorthand names.

https://desire2learn.atlassian.net/browse/QE-651