### PR TITLE
Add missing label descriptions

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -35,4 +35,5 @@
   description: This will not be worked on
   color: ffffff
 - name: released
+  description: Pull requests that have been released
   color: ededed


### PR DESCRIPTION
Updates `.github/labels.yml` to add missing label descriptions so each label has complete metadata.

QE-2110