### PR TITLE
Expand test coverage cases

### DIFF
--- a/test/bin.test.mjs
+++ b/test/bin.test.mjs
@@ -1,24 +1,26 @@
-import { env } from 'process';
+import { env, platform } from 'node:process';
 import { expect } from 'chai';
-import { join } from 'path';
-import { spawnSync } from 'child_process';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import yn from 'yn';
 
-const npmCmd = (process.platform === 'win32') ? 'npm.cmd' : 'npm';
+const npmCmd = `${platform === 'win32' ? 'npm.cmd' : 'npm'} install`;
 const dataDir = join('test', 'data');
 // set this to truthy value if you want to see checker command output
 const { TEST_LOGGING_VERBOSE } = env;
 const verbose = yn(TEST_LOGGING_VERBOSE, false);
 
-const checkProject = (projectPath, install = true) => {
-	const args = [join('bin', 'd2l-license-checker')];
+const checkProject = (projectPath, { install = true, args = [], bin = 'd2l-license-checker' } = {}) => {
+	const checkerArgs = [join('bin', bin)];
 
 	if (projectPath) {
-		args.push(projectPath);
+		checkerArgs.push(projectPath);
 	}
 
+	checkerArgs.push(...args);
+
 	if (install) {
-		const npm = spawnSync(npmCmd, ['install'], { cwd: projectPath, shell: true });
+		const npm = spawnSync(npmCmd, { cwd: projectPath, encoding: 'utf8', shell: true });
 
 		if (npm.error !== undefined) {
 			throw npm.error;
@@ -37,93 +39,242 @@ const checkProject = (projectPath, install = true) => {
 		}
 	}
 
-	const node = spawnSync('node', args);
+	const node = spawnSync('node', checkerArgs, { encoding: 'utf8' });
 
 	if (node.error !== undefined) {
 		throw node.error;
 	}
 
 	if (verbose) {
-		console.log(`Running command "node ${args.join(' ')}"`);
+		console.log(`Running command "node ${checkerArgs.join(' ')}"`);
 		console.log(`stdout:\n${node.stdout}`);
 		console.log(`stderr:\n${node.stderr}`);
 	}
 
-	return node.status;
+	return {
+		status: node.status,
+		stdout: node.stdout || '',
+		stderr: node.stderr || ''
+	};
 };
+
+const checkProjectStatus = (projectPath, options) => checkProject(projectPath, options).status;
 
 const makeTestPath = (proj) => join(dataDir, proj);
 
 describe('license checker', () => {
 	describe('config', () => {
 		it('allows no config file', () => {
-			expect(checkProject(makeTestPath('proj-no-cfg'))).to.equal(0);
+			const path = makeTestPath('proj-no-cfg');
+
+			expect(checkProjectStatus(path)).to.equal(0);
 		});
 
 		it('rejects bad config', () => {
-			expect(checkProject(makeTestPath('proj-bad-cfg'))).to.equal(1);
+			const path = makeTestPath('proj-bad-cfg');
+
+			expect(checkProjectStatus(path)).to.equal(1);
+		});
+
+		it('rejects non-object overrides', () => {
+			const path = makeTestPath('proj-bad-override-type');
+
+			expect(checkProjectStatus(path, { install: false })).to.equal(1);
 		});
 	});
 
 	describe('dependencies', () => {
 		it('accepts none', () => {
-			expect(checkProject(makeTestPath('proj-no-deps'))).to.equal(0);
+			const path = makeTestPath('proj-no-deps');
+
+			expect(checkProjectStatus(path)).to.equal(0);
 		});
 
 		it('ignores dev', () => {
-			expect(checkProject(makeTestPath('proj-ok-dev'))).to.equal(0);
+			const path = makeTestPath('proj-ok-dev');
+
+			expect(checkProjectStatus(path)).to.equal(0);
 		});
 
 		it('ignores prod', () => {
-			expect(checkProject(makeTestPath('proj-ok-prod'))).to.equal(0);
+			const path = makeTestPath('proj-ok-prod');
+
+			expect(checkProjectStatus(path)).to.equal(0);
 		});
 	});
 
 	describe('licenses', () => {
 		it('rejects (dev)', () => {
-			expect(checkProject(makeTestPath('proj-license-issue-dev'))).to.equal(2);
+			const path = makeTestPath('proj-license-issue-dev');
+
+			expect(checkProjectStatus(path)).to.equal(2);
 		});
 
 		it('rejects (prod)', () => {
-			expect(checkProject(makeTestPath('proj-license-issue'))).to.equal(2);
+			const path = makeTestPath('proj-license-issue');
+
+			expect(checkProjectStatus(path)).to.equal(2);
+		});
+
+		it('accepts project-owner', () => {
+			const path = makeTestPath('proj-ok-project-owner');
+
+			expect(checkProjectStatus(path)).to.equal(0);
+		});
+
+		it('accepts public-domain', () => {
+			const path = makeTestPath('proj-ok-public-domain');
+
+			expect(checkProjectStatus(path)).to.equal(0);
+		});
+
+		it('accepts own package', () => {
+			const path = makeTestPath('proj-ok-self');
+
+			expect(checkProjectStatus(path, { install: false })).to.equal(0);
 		});
 	});
 
 	describe('scopes', () => {
 		it('accepts d2l', () => {
-			expect(checkProject(makeTestPath('proj-ok-scope-d2l'), false)).to.equal(0);
+			const path = makeTestPath('proj-ok-scope-d2l');
+
+			expect(checkProjectStatus(path, { install: false })).to.equal(0);
+		});
+
+		it('accepts custom', () => {
+			const path = makeTestPath('proj-ok-scope-custom');
+
+			expect(checkProjectStatus(path, { install: false })).to.equal(0);
 		});
 
 		it('rejects non-whitelisted', () => {
-			expect(checkProject(makeTestPath('proj-license-issue-scope'))).to.equal(2);
+			const path = makeTestPath('proj-license-issue-scope');
+
+			expect(checkProjectStatus(path)).to.equal(2);
 		});
 	});
 
 	describe('overrides', () => {
 		it('accepts in-range', () => {
-			expect(checkProject(makeTestPath('proj-ok-range'))).to.equal(0);
+			const path = makeTestPath('proj-ok-range');
+
+			expect(checkProjectStatus(path)).to.equal(0);
 		});
 
 		it('rejects out-of-range', () => {
-			expect(checkProject(makeTestPath('proj-bad-override-range'))).to.equal(2);
+			const path = makeTestPath('proj-bad-override-range');
+
+			expect(checkProjectStatus(path)).to.equal(2);
 		});
 
 		it('allows special exemption', () => {
-			expect(checkProject(makeTestPath('proj-ok-override-special'))).to.equal(0);
+			const path = makeTestPath('proj-ok-override-special');
+
+			expect(checkProjectStatus(path)).to.equal(0);
+		});
+
+		it('warns unused', () => {
+			const path = makeTestPath('proj-unused-override');
+			const result = checkProject(path, { install: false });
+
+			expect(result.status).to.equal(0);
+			expect(result.stderr).to.contain('WARNING: Manual override');
+		});
+
+		it('ignores unused', () => {
+			const path = makeTestPath('proj-ignore-unused');
+			const result = checkProject(path, { install: false });
+
+			expect(result.status).to.equal(0);
+			expect(result.stderr).to.not.contain('WARNING: Manual override');
+		});
+
+		it('rejects malformed key', () => {
+			const path = makeTestPath('proj-bad-override-key');
+
+			expect(checkProjectStatus(path)).to.equal(2);
+		});
+
+		it('rejects malformed version', () => {
+			const path = makeTestPath('proj-bad-override-version');
+
+			expect(checkProjectStatus(path)).to.equal(2);
+		});
+
+		it('rejects override conflict', () => {
+			const path = makeTestPath('proj-override-conflict');
+
+			expect(checkProjectStatus(path)).to.equal(2);
+		});
+
+		it('accepts wildcard', () => {
+			const path = makeTestPath('proj-ok-override-wildcard');
+
+			expect(checkProjectStatus(path)).to.equal(0);
 		});
 	});
 
 	describe('SPDX expressions', () => {
 		it('allows valid', () => {
-			expect(checkProject(makeTestPath('proj-ok-spdx-expression'))).to.equal(0);
+			const path = makeTestPath('proj-ok-spdx-expression');
+
+			expect(checkProjectStatus(path)).to.equal(0);
 		});
 
 		it('rejects invalid', () => {
-			expect(checkProject(makeTestPath('proj-bad-spdx-expression'))).to.equal(2);
+			const path = makeTestPath('proj-bad-spdx-expression');
+
+			expect(checkProjectStatus(path)).to.equal(2);
+		});
+	});
+
+	describe('flags', () => {
+		it('accepts prod-only', () => {
+			const path = makeTestPath('proj-prod-only');
+
+			expect(checkProjectStatus(path, { args: ['-p'] })).to.equal(0);
+		});
+
+		it('accepts dev-only', () => {
+			const path = makeTestPath('proj-dev-only');
+
+			expect(checkProjectStatus(path, { args: ['-d'] })).to.equal(0);
+		});
+
+		it('rejects conflict', () => {
+			const path = makeTestPath('proj-flag-conflict');
+
+			expect(checkProjectStatus(path, { args: ['-d', '-p'], install: false })).to.equal(1);
+		});
+
+		it('rejects unknown', () => {
+			const path = makeTestPath('proj-unknown-flag');
+
+			expect(checkProjectStatus(path, { args: ['--bogus'], install: false })).to.equal(1);
+		});
+
+		it('outputs template', () => {
+			const path = makeTestPath('proj-template');
+			const result = checkProject(path, { args: ['-t'] });
+
+			expect(result.status).to.equal(2);
+			expect(() => JSON.parse(result.stdout)).to.not.throw();
+			expect(JSON.parse(result.stdout).manualOverrides).to.have.property('modm@0.4.1');
+		});
+	});
+
+	describe('ci', () => {
+		it('warns deprecated', () => {
+			const path = makeTestPath('proj-ci');
+			const result = checkProject(path, { bin: 'license-checker-ci', install: false });
+
+			expect(result.status).to.equal(0);
+			expect(result.stderr).to.contain('license-checker-ci command is deprecated');
 		});
 	});
 
 	it('self test', () => {
-		expect(checkProject('.')).to.equal(0);
+		expect(checkProjectStatus('.', { install: false })).to.equal(0);
 	});
 });

--- a/test/data/proj-bad-override-key/.licensechecker.json
+++ b/test/data/proj-bad-override-key/.licensechecker.json
@@ -1,0 +1,5 @@
+{
+  "manualOverrides": {
+    "modm": "Apache-2.0"
+  }
+}

--- a/test/data/proj-bad-override-key/package.json
+++ b/test/data/proj-bad-override-key/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-bad-override-key",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-bad-override-type/.licensechecker.json
+++ b/test/data/proj-bad-override-type/.licensechecker.json
@@ -1,0 +1,3 @@
+{
+  "manualOverrides": "MIT"
+}

--- a/test/data/proj-bad-override-type/package.json
+++ b/test/data/proj-bad-override-type/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "proj-bad-override-type",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
+}

--- a/test/data/proj-bad-override-version/.licensechecker.json
+++ b/test/data/proj-bad-override-version/.licensechecker.json
@@ -1,0 +1,5 @@
+{
+  "manualOverrides": {
+    "modm@@@": "Apache-2.0"
+  }
+}

--- a/test/data/proj-bad-override-version/package.json
+++ b/test/data/proj-bad-override-version/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-bad-override-version",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-ci/package.json
+++ b/test/data/proj-ci/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "proj-ci",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
+}

--- a/test/data/proj-dev-only/package.json
+++ b/test/data/proj-dev-only/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-dev-only",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-flag-conflict/package.json
+++ b/test/data/proj-flag-conflict/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "proj-flag-conflict",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
+}

--- a/test/data/proj-ignore-unused/.licensechecker.json
+++ b/test/data/proj-ignore-unused/.licensechecker.json
@@ -1,0 +1,6 @@
+{
+  "ignoreUnusedManualOverrides": true,
+  "manualOverrides": {
+    "fake-package@1.0.0": "MIT"
+  }
+}

--- a/test/data/proj-ignore-unused/package.json
+++ b/test/data/proj-ignore-unused/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "proj-ignore-unused",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
+}

--- a/test/data/proj-ok-override-wildcard/.licensechecker.json
+++ b/test/data/proj-ok-override-wildcard/.licensechecker.json
@@ -1,0 +1,8 @@
+{
+  "manualOverrides": {
+    "modm@*": "Apache-2.0",
+    "bson@0.2.22": "Apache-2.0",
+    "kerberos@0.0.4": "Apache-2.0",
+    "mongodb@1.4.14": "Apache-2.0"
+  }
+}

--- a/test/data/proj-ok-override-wildcard/package.json
+++ b/test/data/proj-ok-override-wildcard/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-ok-override-wildcard",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-ok-project-owner/.licensechecker.json
+++ b/test/data/proj-ok-project-owner/.licensechecker.json
@@ -1,0 +1,8 @@
+{
+  "manualOverrides": {
+    "modm@0.4.1": "Project-Owner",
+    "bson@0.2.22": "Apache-2.0",
+    "kerberos@0.0.4": "Apache-2.0",
+    "mongodb@1.4.14": "Apache-2.0"
+  }
+}

--- a/test/data/proj-ok-project-owner/package.json
+++ b/test/data/proj-ok-project-owner/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-ok-project-owner",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-ok-public-domain/.licensechecker.json
+++ b/test/data/proj-ok-public-domain/.licensechecker.json
@@ -1,0 +1,8 @@
+{
+  "manualOverrides": {
+    "modm@0.4.1": "Public-Domain",
+    "bson@0.2.22": "Apache-2.0",
+    "kerberos@0.0.4": "Apache-2.0",
+    "mongodb@1.4.14": "Apache-2.0"
+  }
+}

--- a/test/data/proj-ok-public-domain/package.json
+++ b/test/data/proj-ok-public-domain/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-ok-public-domain",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-ok-scope-custom/.licensechecker.json
+++ b/test/data/proj-ok-scope-custom/.licensechecker.json
@@ -1,0 +1,5 @@
+{
+  "acceptedScopes": [
+    "acme"
+  ]
+}

--- a/test/data/proj-ok-scope-custom/package.json
+++ b/test/data/proj-ok-scope-custom/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "proj-ok-scope-custom",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@acme/private": "0.0.1"
+  }
+}

--- a/test/data/proj-ok-self/package.json
+++ b/test/data/proj-ok-self/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "proj-ok-self",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "GPL-3.0"
+}

--- a/test/data/proj-override-conflict/.licensechecker.json
+++ b/test/data/proj-override-conflict/.licensechecker.json
@@ -1,0 +1,6 @@
+{
+  "manualOverrides": {
+    "modm@0.4.1": "GPL-3.0",
+    "modm@=0.4.1": "Apache-2.0"
+  }
+}

--- a/test/data/proj-override-conflict/package.json
+++ b/test/data/proj-override-conflict/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-override-conflict",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-prod-only/package.json
+++ b/test/data/proj-prod-only/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-prod-only",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "devDependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-template/package.json
+++ b/test/data/proj-template/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "proj-template",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "modm": "0.4.1"
+  }
+}

--- a/test/data/proj-unknown-flag/package.json
+++ b/test/data/proj-unknown-flag/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "proj-unknown-flag",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
+}

--- a/test/data/proj-unused-override/.licensechecker.json
+++ b/test/data/proj-unused-override/.licensechecker.json
@@ -1,0 +1,5 @@
+{
+  "manualOverrides": {
+    "fake-package@1.0.0": "MIT"
+  }
+}

--- a/test/data/proj-unused-override/package.json
+++ b/test/data/proj-unused-override/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "proj-unused-override",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
+}


### PR DESCRIPTION
This expands test coverage in `test/bin.test.mjs` with targeted cases for config validation, license acceptance paths, scope handling, override edge cases, CLI flags, template output, and deprecated binary behavior.

The test harness now supports passing CLI arguments, selecting an alternate bin target, and asserting stdout and stderr output so output based behavior can be verified directly. Each new scenario uses dedicated fixture data in `test/data` so cases remain isolated and easy to reason about.

The self test path was also made more stable by avoiding an unnecessary reinstall step in that case.

New cases added and what they cover:
- rejects non-object overrides: validates config guard for invalid `manualOverrides` type (exit 1)
- accepts project-owner: validates `Project-Owner` non SPDX acceptance path
- accepts public-domain: validates `Public-Domain` non SPDX acceptance path
- accepts own package: validates own package acceptance by package name
- accepts custom: validates user supplied `acceptedScopes` behavior
- warns unused: validates warning when unused manual overrides are present
- ignores unused: validates suppression when `ignoreUnusedManualOverrides` is true
- rejects malformed key: validates malformed override key is skipped and offending package still fails
- rejects malformed version: validates malformed override version range is skipped
- rejects override conflict: validates conflicting override ranges behavior
- accepts wildcard: validates wildcard manual override range matching
- accepts prod-only: validates production-only mode ignores dev-only offender
- accepts dev-only: validates development-only mode ignores prod-only offender
- rejects conflict: validates mutually exclusive `-d` and `-p` flags fail (exit 1)
- rejects unknown: validates strict unknown flag handling (exit 1)
- outputs template: validates `--generate-template` emits JSON overrides on failure
- warns deprecated: validates `license-checker-ci` deprecation warning and delegation

https://desire2learn.atlassian.net/browse/QE-2124