### PR TITLE
Enable verbose test logging controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: determine-node-versions
     strategy:
       fail-fast: false
@@ -65,6 +65,8 @@ jobs:
         run: npm ci
       - name: Run tests
         run: npm test
+        env:
+          TEST_LOGGING_VERBOSE: true
       - name: Report test results
         if: (!cancelled()) && github.actor != 'dependabot[bot]'
         uses: Brightspace/test-reporting-action@main

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "eslint-plugin-mocha": "^11",
         "eslint-plugin-promise": "^7",
         "mocha": "^11",
-        "pre-commit": "^2"
+        "pre-commit": "^2",
+        "yn": "^5"
       },
       "engines": {
         "node": ">=22"
@@ -8665,6 +8666,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-5.1.0.tgz",
+      "integrity": "sha512-TfXLvT6eVsBNIm8rAXTwJYdQFtOXaHQ+rA7LU8HL8C/BFfaSfhvFE5T1rHAdBCbAj808HaqjXVkmo8jmeGOqhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "eslint-plugin-mocha": "^11",
     "eslint-plugin-promise": "^7",
     "mocha": "^11",
-    "pre-commit": "^2"
+    "pre-commit": "^2",
+    "yn": "^5"
   },
   "engines": {
     "node": ">=22"

--- a/test/bin.test.mjs
+++ b/test/bin.test.mjs
@@ -1,10 +1,14 @@
+import { env } from 'process';
 import { expect } from 'chai';
 import { join } from 'path';
 import { spawnSync } from 'child_process';
+import yn from 'yn';
 
 const npmCmd = (process.platform === 'win32') ? 'npm.cmd' : 'npm';
 const dataDir = join('test', 'data');
-const verbose = true; // turn this on if you want to see checker command output
+// set this to truthy value if you want to see checker command output
+const { TEST_LOGGING_VERBOSE } = env;
+const verbose = yn(TEST_LOGGING_VERBOSE, false);
 
 const checkProject = (projectPath, install = true) => {
 	const args = [join('bin', 'd2l-license-checker')];


### PR DESCRIPTION
This updates CI and the test harness to make verbose diagnostics opt-in and controlled by environment variables.

The test job now sets `TEST_LOGGING_VERBOSE=true` and increases timeout from five to ten minutes. In `test/bin.test.mjs`, verbose output is now controlled by `yn(TEST_LOGGING_VERBOSE, false)` instead of a hardcoded flag, and `yn` was added to devDependencies with lockfile updates.

https://desire2learn.atlassian.net/browse/QE-2125