### PR TITLE
QE-2110: Add labeler config and label CI job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.md'
+github-actions:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/*.yml
+javascript:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.js'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -13,6 +13,9 @@
 - name: enhancement
   description: New feature or request
   color: a2eeef
+- name: github-actions
+  description: Pull requests that update GitHub Actions code
+  color: 000000
 - name: good first issue
   description: Good for newcomers
   color: 7057ff
@@ -31,9 +34,9 @@
 - name: stale
   description: This issue or pull request has been inactive for too long and will be closed soon
   color: 6b473a
-- name: wontfix
-  description: This will not be worked on
-  color: ffffff
 - name: released
   description: Pull requests that have been released
   color: ededed
+- name: wontfix
+  description: This will not be worked on
+  color: ffffff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,13 @@ jobs:
           aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
           aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           aws-session-token: ${{secrets.AWS_SESSION_TOKEN}}
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Apply labels
+        uses: Brightspace/third-party-actions@actions/labeler


### PR DESCRIPTION
Adds a `.github/labeler.yml` and a `label` job to `ci.yml` so PRs are labeled automatically.