### PR TITLE
Remove unused bin option from test helper

### DIFF
--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -10,8 +10,8 @@ const dataDir = join('test', 'data');
 const { TEST_LOGGING_VERBOSE } = env;
 const verbose = yn(TEST_LOGGING_VERBOSE, false);
 
-const checkProject = (projectPath, { install = true, args = [], bin = 'd2l-license-checker' } = {}) => {
-	const checkerArgs = [join('bin', bin)];
+const checkProject = (projectPath, { install = true, args = [] } = {}) => {
+	const checkerArgs = [join('bin', 'd2l-license-checker')];
 
 	if (projectPath) {
 		checkerArgs.push(projectPath);


### PR DESCRIPTION
Removes the `bin` option from the `checkProject` test helper since it is no longer needed, inlining the hardcoded `d2l-license-checker` binary path.

https://desire2learn.atlassian.net/browse/QE-2013