### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "/config",
     "/src"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "fix": "npm run fix:eslint",
     "fix:eslint": "npm run lint:eslint -- --fix",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564